### PR TITLE
Change workflow to update dockerhub description on push

### DIFF
--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -79,3 +79,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          repository: peterevans/dockerhub-description


### PR DESCRIPTION
Fixes #14 

Need to be tested by pushing a new tag once merged.