### PR TITLE
Use ARCH_INDEPENDENT Space Team fork of strong_type

### DIFF
--- a/libraries.txt
+++ b/libraries.txt
@@ -2,5 +2,5 @@ rodos,0dd30adb373972b9adf2a4a4eb0b068130f45f53,https://github.com/SpaceTeam/rodo
 etl,cceb5038664a4fa363e79709bc08bd0bb356ae50,https://github.com/ETLCPP/etl.git
 Catch2,v3.1.0,https://github.com/catchorg/Catch2.git
 littlefs,8e53bfeda7716ed7056a2b519bba45f40dea7df0,https://github.com/SpaceTeam/littlefs.git
-strong_type,v14,https://github.com/rollbear/strong_type
+strong_type,db35dfe162a3c758398c638851ff4db9d421a037,https://github.com/SpaceTeam/strong_type.git
 include-what-you-use,0.19,https://github.com/include-what-you-use/include-what-you-use.git


### PR DESCRIPTION
The library was not marked as ARCH_INDEPENDENT, so I created a fork and a PR to fix that. Since I don't know how long it'll take till the PR is merged I choose to reference our fork.