### PR TITLE
Add LLVM APT repository for more up-to-date packages

### DIFF
--- a/linux-x86/Dockerfile
+++ b/linux-x86/Dockerfile
@@ -2,6 +2,12 @@ FROM ubuntu:24.04
 
 ENV HOME="/"
 
+# Add the LLVM APT repository for more up-to-date packages and install the GPG key
+RUN apt-get update -qq && apt-get install -y -qq wget
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble main" > /etc/apt/sources.list.d/llvm-sources.list \
+    && echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble main" >> /etc/apt/sources.list.d/llvm-sources.list
+
 RUN dpkg --add-architecture i386 && apt-get update -qq && apt-get install -y -qq \
     ca-certificates \
     ccache \

--- a/linux-x86/Dockerfile
+++ b/linux-x86/Dockerfile
@@ -3,10 +3,10 @@ FROM ubuntu:24.04
 ENV HOME="/"
 
 # Add the LLVM APT repository for more up-to-date packages
-RUN apt-get update -qq && apt-get install -y -qq wget gpg
-RUN wget -O /usr/share/keyrings/llvm-snapshot.gpg https://apt.llvm.org/llvm-snapshot.gpg.key \
-    && gpg --no-tty --batch --yes --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg /usr/share/keyrings/llvm-snapshot.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble main" > /etc/apt/sources.list.d/llvm-sources.list \
+RUN apt-get update -qq && apt-get install -y -qq curl gpg
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --no-tty --batch --yes --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
+RUN chmod a+r /usr/share/keyrings/llvm-snapshot.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble main" > /etc/apt/sources.list.d/llvm-sources.list \
     && echo "deb-src [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble main" >> /etc/apt/sources.list.d/llvm-sources.list
 
 RUN dpkg --add-architecture i386 && apt-get update -qq && apt-get install -y -qq \

--- a/linux-x86/Dockerfile
+++ b/linux-x86/Dockerfile
@@ -2,11 +2,12 @@ FROM ubuntu:24.04
 
 ENV HOME="/"
 
-# Add the LLVM APT repository for more up-to-date packages and install the GPG key
-RUN apt-get update -qq && apt-get install -y -qq wget
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble main" > /etc/apt/sources.list.d/llvm-sources.list \
-    && echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble main" >> /etc/apt/sources.list.d/llvm-sources.list
+# Add the LLVM APT repository for more up-to-date packages
+RUN apt-get update -qq && apt-get install -y -qq wget gpg
+RUN wget -O /usr/share/keyrings/llvm-snapshot.gpg https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && gpg --no-tty --batch --yes --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg /usr/share/keyrings/llvm-snapshot.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble main" > /etc/apt/sources.list.d/llvm-sources.list \
+    && echo "deb-src [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble main" >> /etc/apt/sources.list.d/llvm-sources.list
 
 RUN dpkg --add-architecture i386 && apt-get update -qq && apt-get install -y -qq \
     ca-certificates \


### PR DESCRIPTION
Fixes #80 

The reason this is necessary is that the "normal" clangd-19 is version 19.1.1 which always crashes on our code. The newer version from the LLVM APT repo (19.1.7) works just fine.