### PR TITLE
Fix installation of littlefs for COBC target

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,10 +81,10 @@ if [[ $1 == "linux" ]]; then
 else
   cmake --toolchain ../stm32f411.cmake -DLFS_THREADSAFE=ON -DLFS_NO_MALLOC=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DEBUG_POSTFIX=d -S . -B build/cobc/Debug
   cmake --build ./build/cobc/Debug
-  sudo cmake --install build/cobc --prefix "$2"/Debug
+  sudo cmake --install build/cobc/Debug --prefix "$2"
   cmake --toolchain ../stm32f411.cmake -DLFS_THREADSAFE=ON -DLFS_NO_MALLOC=OFF -DCMAKE_BUILD_TYPE=MinSizeRel -S . -B build/cobc/MinSizeRel
   cmake --build ./build/cobc/MinSizeRel
-  sudo cmake --install build/cobc --prefix "$2"/MinSizeRel
+  sudo cmake --install build/cobc/MinSizeRel --prefix "$2"
 fi
 cd ..
 


### PR DESCRIPTION
In #78 I introduced a copy-and-paste error resulting in the wrong build and prefix paths when installing littlefs for the COBC target.