### PR TITLE
Revert "Update Rodos to support LTO/IPO"

### DIFF
--- a/libraries.txt
+++ b/libraries.txt
@@ -1,4 +1,4 @@
-rodos,6f3ed1495417942d6d8fff582f694bc5c519ea50,https://github.com/SpaceTeam/rodos.git
+rodos,48261b4a7816feac1f5b47105bebd001058ff2b8,https://github.com/SpaceTeam/rodos.git
 etl,20.43.0,https://github.com/ETLCPP/etl.git
 Catch2,v3.8.1,https://github.com/catchorg/Catch2.git
 littlefs,8e53bfeda7716ed7056a2b519bba45f40dea7df0,https://github.com/SpaceTeam/littlefs.git


### PR DESCRIPTION
This reverts commit c4187c9a8e2e3e21a9c0fd182ffaa3c79df36025.

For some reason, compiling Rodos with LTO/IPO completely breaks our firmware, so we just don't do it.